### PR TITLE
[add]basic Auth(#125)

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -2,6 +2,11 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  env: {
+    ENABLE_BASIC_AUTH: process.env.ENABLE_BASIC_AUTH,
+    BASIC_AUTH_USER: process.env.BASIC_AUTH_USER,
+    BASIC_AUTH_PASSWORD: process.env.BASIC_AUTH_PASSWORD,
+  }
 }
 
 module.exports = nextConfig

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export const middleware = (req: NextRequest) => {
+  if (req.nextUrl.pathname.startsWith('/admin')) {
+    const authorizationHeader = req.headers.get('authorization')
+
+    if (authorizationHeader) {
+      const basicAuth = authorizationHeader.split(' ')[1]
+      const [user, password] = atob(basicAuth).split(':')
+
+      if (
+        user === process.env.BASIC_AUTH_USER &&
+        password === process.env.BASIC_AUTH_PASSWORD
+      ) {
+        return NextResponse.next()
+      }
+    }
+
+    const url = req.nextUrl
+    url.pathname = '/api/basicAuth'
+
+    return NextResponse.rewrite(url)
+  }
+
+  return NextResponse.next()
+}

--- a/app/src/pages/api/basicAuth.ts
+++ b/app/src/pages/api/basicAuth.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_: NextApiRequest, res: NextApiResponse) {
+  res.statusCode = 401
+  res.setHeader('WWW-authenticate', 'Basic realm="Secure Area"')
+  res.end('Basic Auth Required')
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     environment:
       SSR_API_URI: 'http://localhost:8000/api'
       CSR_API_URI: 'http://api:8000/api'
+      BASIC_AUTH_USER: "hoge"
+      BASIC_AUTH_PASSWORD: "fuga"
     depends_on:
       - api
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #125 

## 概要
<!-- 開発内容の概要を記載 -->
basic認証機能の実装を行いました。

### 手元環境で必要なこと
- `app/.env.local` を作成し、以下の要旨を追加する
  - `hoge`, `fuga` にあたる場所に任意のパスワードを設定することでbasic認証ができる
```
BASIC_AUTH_USER="hoge"
BASIC_AUTH_PASSWORD="fuga"
```

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `http://localhost:8888/admin`
- スクリーンショット
<img width="1440" alt="スクリーンショット 2022-09-01 23 29 58" src="https://user-images.githubusercontent.com/71711872/187939660-91523d03-63ec-45c8-af5f-2679e19f9db8.png">

## テスト項目
<!-- テストしてほしい内容を記載 -->
- `app/.env.local` に `BASIC_AUTH_USER` と `BASIC_AUTH_PASSWORD` を追加し、追加したユーザ名・パスワードを入力するとadminページに遷移するか
- ユーザ名・パスワードが異なる場合は再度入力画面（入力モーダル）が表示されるか

## 備考
basic認証からログアウトしたい場合は http://hoge@localhost:8888/admin のように、 `localhost` の前に `適当な文字@` を追加することでログアウトできる