### PR TITLE
[add]ユーザページで当選者を確認する(#176)

### DIFF
--- a/app/src/components/MobileLayout/MobileLayout.module.css
+++ b/app/src/components/MobileLayout/MobileLayout.module.css
@@ -118,3 +118,15 @@
   height: 1px;
   margin-top: 1rem;
 }
+
+.winner_id{
+  font-size: 1.25rem;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.winner_number{
+  font-size: 1.25rem;
+  margin-top: 1rem;
+  text-align: center;
+}

--- a/app/src/components/MobileLayout/MobileLayout.tsx
+++ b/app/src/components/MobileLayout/MobileLayout.tsx
@@ -1,5 +1,16 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import ml from './MobileLayout.module.css'
+import { get } from '@/utils/api_methods'
+
+interface Winner {
+  id: number
+  place_id: string
+  number: string
+  updated_at: string
+  created_at: string
+  detail: string
+}
+
 interface MobileLayoutProps {
   align?: string
   justify?: string
@@ -8,7 +19,17 @@ interface MobileLayoutProps {
   gap?: string
   children?: React.ReactNode
 }
+ 
 const MobileLayout = (props: MobileLayoutProps) => {
+  const [winners, setWinners] = React.useState<Winner[]>()
+  useEffect(() => {
+    const getUrl = process.env.CSR_API_URI + '/winners'
+    const getWinners = async (url: string) => {
+      setWinners(await get(url));
+    }
+    getWinners(getUrl);
+  }, [])
+   
   return (
     <div className={`${ml.container}`}>
       <div className={`${ml.odometerContainer}`}>
@@ -38,6 +59,14 @@ const MobileLayout = (props: MobileLayoutProps) => {
               </th>
             </tr>
           </thead>
+          <tbody>
+            {winners?.map((winner: Winner) => (
+              <tr>
+                <td className={`${ml.winner_id} font-serif`}>{winner.id}</td>
+                <td className={`${ml.winner_number} font-serif`}>{winner.number}</td>
+              </tr>
+            ))}
+          </tbody>
         </table>
         <img src="/side.png" className={`${ml.center4}`} />
       </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #176 

## 概要
<!-- 開発内容の概要を記載 -->
ユーザページで当選者を確認できるようにした

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- 通常時
<img width="311" alt="スクリーンショット 2022-09-06 19 46 12" src="https://user-images.githubusercontent.com/71711872/188616153-b0957c68-2fcb-4382-a181-aee2d7cb8f13.png">
- スクロール時
<img width="306" alt="スクリーンショット 2022-09-06 19 47 00" src="https://user-images.githubusercontent.com/71711872/188616225-3fa5ee1e-ddd0-40d9-a200-d49930ce77f9.png">


## テスト項目
<!-- テストしてほしい内容を記載 -->
- 当選者を追加して「当選番号」と「学籍番号」がスクリーンショットの通りに表示されるか

## 備考
