### PR TITLE
抽選画面でオドメータが回り終わった後に抽選画面下部に追加

### DIFF
--- a/app/src/components/MobileLayout/MobileLayout.tsx
+++ b/app/src/components/MobileLayout/MobileLayout.tsx
@@ -27,10 +27,10 @@ function useDelay(time: number) {
 
 const MobileLayout = (props: MobileLayoutProps) => {
   const getUrl = process.env.CSR_API_URI + '/winners'
-  // 5秒後に当選者を取得するために遅延関数を定義
-  const delayed = useDelay(5000);
+  // 10秒後に当選者を取得するために遅延関数を定義
+  const delayed = useDelay(10000);
    
-  //  当選5秒後に当選者を更新
+  //  当選10秒後に当選者を更新
   const getWinners = useCallback(async () => {
     try {
       const response = await get(getUrl)

--- a/app/src/components/MobileLayout/MobileLayout.tsx
+++ b/app/src/components/MobileLayout/MobileLayout.tsx
@@ -1,15 +1,7 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import ml from './MobileLayout.module.css'
 import { get } from '@/utils/api_methods'
-
-interface Winner {
-  id: number
-  place_id: string
-  number: string
-  updated_at: string
-  created_at: string
-  detail: string
-}
+import { Winner } from '@/pages/index'
 
 interface MobileLayoutProps {
   align?: string
@@ -18,18 +10,44 @@ interface MobileLayoutProps {
   height?: string
   gap?: string
   children?: React.ReactNode
+  isAddWinner: boolean
+  setIsAddWinner: any
+  winners: Winner[]
+  setWinners: any
+}
+
+// Delayを設定する
+function useDelay(time: number) {
+  return React.useCallback(async () => {
+    return await new Promise((resolve) => {
+      setTimeout(resolve, time);
+    });
+  }, [time]);
 }
 
 const MobileLayout = (props: MobileLayoutProps) => {
-  const [winners, setWinners] = React.useState<Winner[]>()
-  useEffect(() => {
-    const getUrl = process.env.CSR_API_URI + '/winners'
-    const getWinners = async (url: string) => {
-      setWinners(await get(url))
+  const getUrl = process.env.CSR_API_URI + '/winners'
+  // 5秒後に当選者を取得するために遅延関数を定義
+  const delayed = useDelay(5000);
+   
+  //  当選5秒後に当選者を更新
+  const getWinners = useCallback(async () => {
+    try {
+      const response = await get(getUrl)
+      // 当選者を更新
+      delayed().then(() => props.setWinners(response));
+      // addWinnerフラグをfalseにする
+      delayed().then(() => props.setIsAddWinner(false));
+    } catch (err) {
+      console.error(err)
     }
-    getWinners(getUrl)
-  }, [])
-
+  }, [props.isAddWinner])
+  
+  // props.isAddWinnerがtrueになった時にgetWinnersを実行
+  useEffect(() => {
+    getWinners()
+  }, [props.isAddWinner])
+   
   return (
     <div className={`${ml.container}`}>
       <div className={`${ml.odometerContainer}`}>
@@ -60,8 +78,8 @@ const MobileLayout = (props: MobileLayoutProps) => {
             </tr>
           </thead>
           <tbody>
-            {winners?.map((winner: Winner) => (
-              <tr>
+            {props.winners?.map((winner: Winner) => (
+              <tr key={winner.id}>
                 <td className={`${ml.winner_id} font-serif`}>{winner.id}</td>
                 <td className={`${ml.winner_number} font-serif`}>{winner.number}</td>
               </tr>

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,11 +1,40 @@
 import MobileLayout from '@/components/MobileLayout'
 import type { NextPage } from 'next'
+import { get } from '@/utils/api_methods'
 import Odometer from '@/components/OdometerMini'
 import { useEffect, useRef, useState } from 'react'
 
-const Home: NextPage = () => {
+export interface Winner {
+  id: number
+  place_id: string
+  number: string
+  updated_at: string
+  created_at: string
+  detail: string
+}
+ 
+interface Props {
+  winners: Winner[]
+}
+
+export const getServerSideProps = async () => {
+  const getUrl = process.env.SSR_API_URI + '/winners'
+  const json = await get(getUrl)
+  return {
+    props: {
+      winners: json,
+    },
+  }
+}
+
+
+const Home: NextPage<Props> = (props) => {
   const socketRef = useRef<WebSocket>()
   const [randomMessage, setRandomMessage] = useState('')
+  // 当選者が追加された時に、時間を空けて当選者を取得するためのフラグ
+  const [isAddWinner, setIsAddWinner] = useState(false);
+  // ページ読み込み時にwinnersを表示
+  const [winners, setWinners] = useState<Winner[]>(props.winners)
 
   useEffect(() => {
     socketRef.current = new WebSocket(process.env.WS_API_URI)
@@ -14,9 +43,9 @@ const Home: NextPage = () => {
       let json = JSON.parse(event.data)
       if (json.client == 'Random') {
         setRandomMessage(json.message)
+        setIsAddWinner(true);
       }
     }
-
     return () => {
       if (socketRef.current == null) {
         return
@@ -25,11 +54,9 @@ const Home: NextPage = () => {
     }
   }, [])
   return (
-    <>
-      <MobileLayout>
-        <Odometer value={randomMessage} />
-      </MobileLayout>
-    </>
+    <MobileLayout isAddWinner={isAddWinner} setIsAddWinner={setIsAddWinner} winners={winners} setWinners={setWinners}>
+      <Odometer value={randomMessage} />
+    </MobileLayout>
   )
 }
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 概要
<!-- 開発内容の概要を記載 -->
resolve #192 

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
動作確認用にボタン押す -> オドメーターが回る -> 当選番号が追加される の流れを収録したので確認してみてください

https://user-images.githubusercontent.com/71711872/189297726-1579dba7-6689-488f-87a5-9e2b2749f608.mov

## テスト項目
<!-- テストしてほしい内容を記載 -->
- 抽選されて10秒後かつオドメータが周り終わった後に当選画面の「学籍番号」の部分に当選した学籍番号が追加されるか

