### PR TITLE
[add]userに紐づいたeventの表示(#257)

### DIFF
--- a/go_api/docs/docs.go
+++ b/go_api/docs/docs.go
@@ -248,6 +248,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/events/users":{
+            "get":{
+                tags: ["event"],
+                "description":"全イベントのユーザーの取得",
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "schema":{
+                            "type":"array",
+                        }
+                    }
+                }
+            }
+        },
+        "/events/{id}/users":{
+            "get":{
+                tags: ["event"],
+                "description":"IDを指定してイベントのユーザーの取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "type": "integer",
+                        "in": "path",
+                        "description": "イベントID",
+                        "required": true
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "schema":{
+                            "type":"object",
+                        }
+                    }
+                }
+            }
+        },
         "/users":{
             "get":{
                 tags: ["user"],

--- a/go_api/domain/event.go
+++ b/go_api/domain/event.go
@@ -10,7 +10,7 @@ type Event struct {
 	Description string    `json:"description" gorm:"not null"`
 	CreatedAT   time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT   time.Time `json:"updated_at" gorm:"not null"`
-	Users       []User    `gorm:"many2many:event_user;"`
+	Users       []User    `json:"user,omitempty" gorm:"many2many:event_user;"`
 }
 
 type Events []Event

--- a/go_api/domain/event.go
+++ b/go_api/domain/event.go
@@ -10,6 +10,7 @@ type Event struct {
 	Description string    `json:"description" gorm:"not null"`
 	CreatedAT   time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT   time.Time `json:"updated_at" gorm:"not null"`
+	Users       []User    `gorm:"many2many:event_user;"`
 }
 
 type Events []Event
@@ -20,4 +21,6 @@ type EventRepository interface {
 	Create(user *Event) error
 	Update(user *Event) error
 	Delete(id int) error
+	FindAllLinkUser() (*Events, error)
+	FindLinkUser(id int) (*Event, error)
 }

--- a/go_api/domain/user.go
+++ b/go_api/domain/user.go
@@ -11,7 +11,7 @@ type User struct {
 	Number    uint64    `json:"number" gorm:"unique;not null"`
 	CreatedAT time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT time.Time `json:"updated_at" gorm:"not null"`
-	Event     []Events  `gorm:"many2many:event_user;"`
+	Events    []Events  `json:"event,omitempty" gorm:"many2many:event_user;"`
 }
 
 type Users []User

--- a/go_api/domain/user.go
+++ b/go_api/domain/user.go
@@ -11,7 +11,7 @@ type User struct {
 	Number    uint64    `json:"number" gorm:"unique;not null"`
 	CreatedAT time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT time.Time `json:"updated_at" gorm:"not null"`
-	Event     []Event   `gorm:"many2many:event_user;"`
+	Event     []Events  `gorm:"many2many:event_user;"`
 }
 
 type Users []User

--- a/go_api/infrastructure/event.go
+++ b/go_api/infrastructure/event.go
@@ -56,3 +56,23 @@ func (e *EventInfrastructure) Delete(id int) error {
 	}
 	return nil
 }
+
+// ユーザーに紐づいた全イベントの取得
+func (e *EventInfrastructure) FindAllLinkUser() (*domain.Events, error) {
+	events := domain.Events{}
+	if err := e.db.Preload("Users").Find(&events).Error; err != nil {
+		return nil, err
+	}
+	e.db.Debug().Preload("Users").Find(&events)
+	return &events, nil
+}
+
+// ユーザーに紐づいたイベントの取得
+func (e *EventInfrastructure) FindLinkUser(id int) (*domain.Event, error) {
+	event := domain.Event{}
+	if err := e.db.Preload("Users").First(&event, id).Error; err != nil {
+		return nil, err
+	}
+	e.db.Debug().Preload("Users").First(&event, id)
+	return &event, nil
+}

--- a/go_api/interfaces/event_controller.go
+++ b/go_api/interfaces/event_controller.go
@@ -21,6 +21,8 @@ type EventController interface {
 	CreateEvent(c echo.Context) error
 	UpdateEvent(c echo.Context) error
 	DeleteEvent(c echo.Context) error
+	IndexEventLinkUser(c echo.Context) error
+	ShowEventLinkUser(c echo.Context) error
 }
 
 func NewEventController(eu usecase.EventUsecase) EventController {
@@ -88,4 +90,23 @@ func (e *eventController) DeleteEvent(c echo.Context) error {
 		return err
 	}
 	return c.String(http.StatusOK, "Delete event")
+}
+
+// ユーザーに紐づいたイベントの取得
+func (e *eventController) IndexEventLinkUser(c echo.Context) error {
+	events, err := e.eventUsecase.FindAllEventsLinkUser()
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, events)
+}
+
+// イベントに紐づいたユーザーの取得
+func (e *eventController) ShowEventLinkUser(c echo.Context) error {
+	id, _ := strconv.Atoi(c.Param("id"))
+	event, err := e.eventUsecase.FindEventLinkUser(id)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, event)
 }

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -64,6 +64,8 @@ func main() {
 	e.POST("/events", eventController.CreateEvent)
 	e.PUT("/events/:id", eventController.UpdateEvent)
 	e.DELETE("/events/:id", eventController.DeleteEvent)
+	e.GET("/events/users", eventController.IndexEventLinkUser)
+	e.GET("/events/:id/users", eventController.ShowEventLinkUser)
 
 	// users
 	e.GET("/users", userController.IndexUser)

--- a/go_api/usecase/event_usecase.go
+++ b/go_api/usecase/event_usecase.go
@@ -15,6 +15,8 @@ type EventUsecase interface {
 	CreateEvent(event *domain.Event) error
 	UpdateEvent(event *domain.Event) error
 	DeleteEvent(id int) error
+	FindAllEventsLinkUser() (*domain.Events, error)
+	FindEventLinkUser(id int) (*domain.Event, error)
 }
 
 func NewEventUsecase(er domain.EventRepository) EventUsecase {
@@ -61,4 +63,22 @@ func (e *eventUsecase) DeleteEvent(id int) error {
 		return err
 	}
 	return nil
+}
+
+// ユーザーに紐づいた全イベントの取得
+func (e *eventUsecase) FindAllEventsLinkUser() (*domain.Events, error) {
+	events, err := e.eventRepository.FindAllLinkUser()
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// ユーザーに紐づいたイベントの取得
+func (e *eventUsecase) FindEventLinkUser(id int) (*domain.Event, error) {
+	event, err := e.eventRepository.FindLinkUser(id)
+	if err != nil {
+		return nil, err
+	}
+	return event, nil
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 概要
issue256を参考にuserに紐づいたevent取得APIを作成しました。

手順
`make run`
db立ち上げてからmysqlに以下の文を
`insert into event_user values (1,2);`
`http://localhost:1323/swagger/index.html#/`
`events/users`と`events/{id}/users`を叩いて動いているか

<!-- 開発内容の概要を記載 -->
resolve #257

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
- スクリーンショット
<img width="300" alt="image" src="https://user-images.githubusercontent.com/106811268/204454479-07c84bf0-d773-4186-9a3d-50492dac2193.png">

## テスト項目
<!-- テストしてほしい内容を記載 -->
-画像みたいに表示ができているか確認お願いします
-
-

## 備考
今のままだとdomainのuser,eventにそれぞれにカラムを追加しているためnullのやつが出てきてなんか変な感じになってます。