### PR TITLE
[add]Winnerに紐づくUserを表示するAPIの作成(#268)

### DIFF
--- a/go_api/docs/docs.go
+++ b/go_api/docs/docs.go
@@ -532,6 +532,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/winners/users":{
+            "get":{
+                tags: ["winner"],
+                "description":"全ウィナーのユーザーの取得",
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "schema":{
+                            "type":"array",
+                        }
+                    }
+                }
+            }
+        },
+        "/winners/{id}/users":{
+            "get":{
+                tags: ["winner"],
+                "description":"IDを指定してウィナーのユーザーの取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "type": "integer",
+                        "in": "path",
+                        "description": "ウィナーID",
+                        "required": true
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "schema":{
+                            "type":"object",
+                        }
+                    }
+                }
+            }
+        },
     }
 }`
 

--- a/go_api/domain/winner.go
+++ b/go_api/domain/winner.go
@@ -14,12 +14,20 @@ type Winner struct {
 
 type Winners []Winner
 
+type WinnerIncludedUser struct {
+	ID		 uint   `json:"id"`
+	Name   string `json:"name"`
+	Number uint64 `json:"number"`
+}
+
+type WinnerIncludedUsers []WinnerIncludedUser
+
 type WinnerRepository interface {
 	FindAll() (*Winners, error)
 	Find(id int) (*Winner, error)
 	Create(winner *Winner) error
 	Update(winner *Winner) error
 	Delete(id int) error
-	FindAllLinkUser() (*Winners, error)
+	FindAllLinkUser() (*WinnerIncludedUsers, error)
 	FindLinkUser(id int) (*Winner, error)
 }

--- a/go_api/domain/winner.go
+++ b/go_api/domain/winner.go
@@ -14,12 +14,14 @@ type Winner struct {
 
 type Winners []Winner
 
+type WinnersIncludeUsers []User
+
 type WinnerRepository interface {
 	FindAll() (*Winners, error)
 	Find(id int) (*Winner, error)
 	Create(winner *Winner) error
 	Update(winner *Winner) error
 	Delete(id int) error
-	FindAllLinkUser() (*Winners, error)
-	FindLinkUser(id int) (*Winner, error)
+	FindAllLinkUser() (*WinnersIncludeUsers, error)
+	FindLinkUser(id int) (*WinnersIncludeUsers, error)
 }

--- a/go_api/domain/winner.go
+++ b/go_api/domain/winner.go
@@ -9,6 +9,7 @@ type Winner struct {
 	UserID    uint      `json:"user_id" gorm:"not null"`
 	CreatedAT time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT time.Time `json:"updated_at" gorm:"not null"`
+	Users     Users     `json:"user,omitempty" gorm:"foreignKey:ID;references:UserID;not null"`
 }
 
 type Winners []Winner
@@ -19,4 +20,6 @@ type WinnerRepository interface {
 	Create(winner *Winner) error
 	Update(winner *Winner) error
 	Delete(id int) error
+	FindAllLinkUser() (*Winners, error)
+	FindLinkUser(id int) (*Winner, error)
 }

--- a/go_api/domain/winner.go
+++ b/go_api/domain/winner.go
@@ -9,12 +9,9 @@ type Winner struct {
 	UserID    uint      `json:"user_id" gorm:"not null"`
 	CreatedAT time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT time.Time `json:"updated_at" gorm:"not null"`
-	Users     Users     `json:"user,omitempty" gorm:"foreignKey:ID;references:UserID;not null"`
 }
 
 type Winners []Winner
-
-type WinnersIncludeUsers []User
 
 type WinnerRepository interface {
 	FindAll() (*Winners, error)
@@ -22,6 +19,6 @@ type WinnerRepository interface {
 	Create(winner *Winner) error
 	Update(winner *Winner) error
 	Delete(id int) error
-	FindAllLinkUser() (*WinnersIncludeUsers, error)
-	FindLinkUser(id int) (*WinnersIncludeUsers, error)
+	FindAllLinkUser() (*Users, error)
+	FindLinkUser(id int) (*User, error)
 }

--- a/go_api/infrastructure/winner.go
+++ b/go_api/infrastructure/winner.go
@@ -61,3 +61,23 @@ func (w *WinnerInfrastructure) Delete(id int) error {
 	w.db.Debug().Delete(&winner, id)
 	return nil
 }
+
+// ユーザーに紐づいた全ウィナーの取得
+func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.Winners, error) {
+	winners := domain.Winners{}
+	if err := w.db.Preload("Users").Joins("inner join users on winners.user_id = users.id").Find(&winners).Error; err != nil {
+		return nil, err
+	}
+	w.db.Debug().Preload("Users").Joins("inner join users on winners.user_id = users.id").Find(&winners)
+	return &winners, nil
+}
+
+// ユーザーに紐づいたウィナーの取得
+func (w *WinnerInfrastructure) FindLinkUser(id int) (*domain.Winner, error) {
+	winner := domain.Winner{}
+	if err := w.db.Preload("Users").Joins("inner join users on winners.user_id = users.id").First(&winner, id).Error; err != nil {
+		return nil, err
+	}
+	w.db.Debug().Preload("Users").Joins("inner join users on winners.user_id = users.id").First(&winner, id)
+	return &winner, nil
+}

--- a/go_api/infrastructure/winner.go
+++ b/go_api/infrastructure/winner.go
@@ -63,13 +63,13 @@ func (w *WinnerInfrastructure) Delete(id int) error {
 }
 
 // ユーザーに紐づいた全ウィナーの取得
-func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.Winners, error) {
-	winners := domain.Winners{}
-	if err := w.db.Preload("Users").Joins("inner join users on winners.user_id = users.id").Find(&winners).Error; err != nil {
+func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.WinnerIncludedUsers, error) {
+	winnersIncludeUsers := domain.WinnerIncludedUsers{}
+	if err := w.db.Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").Scan(&winnersIncludeUsers).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Preload("Users").Joins("inner join users on winners.user_id = users.id").Find(&winners)
-	return &winners, nil
+	w.db.Debug().Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").Scan(&winnersIncludeUsers)
+	return &winnersIncludeUsers, nil
 }
 
 // ユーザーに紐づいたウィナーの取得

--- a/go_api/infrastructure/winner.go
+++ b/go_api/infrastructure/winner.go
@@ -63,21 +63,21 @@ func (w *WinnerInfrastructure) Delete(id int) error {
 }
 
 // ユーザーに紐づいた全ウィナーの取得
-func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.Winners, error) {
-	winners := domain.Winners{}
-	if err := w.db.Table("winners").Select("users.name").Joins("inner join users on winners.user_id = users.id").Find(&winners).Error; err != nil {
+func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.WinnersIncludeUsers, error) {
+	winnersIncludeUsers := domain.WinnersIncludeUsers{}
+	if err := w.db.Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").Scan(&winnersIncludeUsers).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Table("winners").Select("users.name").Joins("inner join users on winners.user_id = users.id").Find(&winners)
-	return &winners, nil
+	w.db.Debug().Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").Scan(&winnersIncludeUsers)
+	return &winnersIncludeUsers, nil
 }
 
 // ユーザーに紐づいたウィナーの取得
-func (w *WinnerInfrastructure) FindLinkUser(id int) (*domain.Winner, error) {
-	winner := domain.Winner{}
-	if err := w.db.Preload("Users").First(&winner, id).Error; err != nil {
+func (w *WinnerInfrastructure) FindLinkUser(id int) (*domain.WinnersIncludeUsers, error) {
+	winnersIncludeUsers := domain.WinnersIncludeUsers{}
+	if err := w.db.Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").First(&winnersIncludeUsers, id).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Preload("Users").First(&winner, id)
-	return &winner, nil
+	w.db.Debug().Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").First(&winnersIncludeUsers, id)
+	return &winnersIncludeUsers, nil
 }

--- a/go_api/infrastructure/winner.go
+++ b/go_api/infrastructure/winner.go
@@ -65,19 +65,20 @@ func (w *WinnerInfrastructure) Delete(id int) error {
 // ユーザーに紐づいた全ウィナーの取得
 func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.Winners, error) {
 	winners := domain.Winners{}
-	if err := w.db.Preload("Users").Joins("inner join users on winners.user_id = users.id").Find(&winners).Error; err != nil {
+	Winner := domain.Winners{}
+	if err := w.db.Preload("Users").Where(&Winner{Users: ""}).Find(&winners).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Preload("Users").Joins("inner join users on winners.user_id = users.id").Find(&winners)
+	w.db.Debug().Preload("Users").Select("user_id").Find(&winners)
 	return &winners, nil
 }
 
 // ユーザーに紐づいたウィナーの取得
 func (w *WinnerInfrastructure) FindLinkUser(id int) (*domain.Winner, error) {
 	winner := domain.Winner{}
-	if err := w.db.Preload("Users").Joins("inner join users on winners.user_id = users.id").First(&winner, id).Error; err != nil {
+	if err := w.db.Preload("Users").First(&winner, id).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Preload("Users").Joins("inner join users on winners.user_id = users.id").First(&winner, id)
+	w.db.Debug().Preload("Users").First(&winner, id)
 	return &winner, nil
 }

--- a/go_api/infrastructure/winner.go
+++ b/go_api/infrastructure/winner.go
@@ -63,8 +63,8 @@ func (w *WinnerInfrastructure) Delete(id int) error {
 }
 
 // ユーザーに紐づいた全ウィナーの取得
-func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.WinnersIncludeUsers, error) {
-	winnersIncludeUsers := domain.WinnersIncludeUsers{}
+func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.Users, error) {
+	winnersIncludeUsers := domain.Users{}
 	if err := w.db.Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").Scan(&winnersIncludeUsers).Error; err != nil {
 		return nil, err
 	}
@@ -73,11 +73,11 @@ func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.WinnersIncludeUsers, e
 }
 
 // ユーザーに紐づいたウィナーの取得
-func (w *WinnerInfrastructure) FindLinkUser(id int) (*domain.WinnersIncludeUsers, error) {
-	winnersIncludeUsers := domain.WinnersIncludeUsers{}
-	if err := w.db.Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").First(&winnersIncludeUsers, id).Error; err != nil {
+func (w *WinnerInfrastructure) FindLinkUser(id int) (*domain.User, error) {
+	winnersIncludeUser := domain.User{}
+	if err := w.db.Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").First(&winnersIncludeUser, id).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").First(&winnersIncludeUsers, id)
-	return &winnersIncludeUsers, nil
+	w.db.Debug().Table("winners").Select("users.id,users.name,users.number").Joins("inner join users on winners.user_id = users.id").First(&winnersIncludeUser, id)
+	return &winnersIncludeUser, nil
 }

--- a/go_api/infrastructure/winner.go
+++ b/go_api/infrastructure/winner.go
@@ -65,11 +65,10 @@ func (w *WinnerInfrastructure) Delete(id int) error {
 // ユーザーに紐づいた全ウィナーの取得
 func (w *WinnerInfrastructure) FindAllLinkUser() (*domain.Winners, error) {
 	winners := domain.Winners{}
-	Winner := domain.Winners{}
-	if err := w.db.Preload("Users").Where(&Winner{Users: ""}).Find(&winners).Error; err != nil {
+	if err := w.db.Table("winners").Select("users.name").Joins("inner join users on winners.user_id = users.id").Find(&winners).Error; err != nil {
 		return nil, err
 	}
-	w.db.Debug().Preload("Users").Select("user_id").Find(&winners)
+	w.db.Debug().Table("winners").Select("users.name").Joins("inner join users on winners.user_id = users.id").Find(&winners)
 	return &winners, nil
 }
 

--- a/go_api/interfaces/winner_controller.go
+++ b/go_api/interfaces/winner_controller.go
@@ -21,6 +21,8 @@ type WinnerController interface {
 	CreateWinner(c echo.Context) error
 	UpdateWinner(c echo.Context) error
 	DeleteWinner(c echo.Context) error
+	IndexWinnerLinkUser(c echo.Context) error
+	ShowWinnerLinkUser(c echo.Context) error
 }
 
 func NewWinnerController(wu usecase.WinnerUsecase) WinnerController {
@@ -84,4 +86,23 @@ func (w *winnerController) DeleteWinner(c echo.Context) error {
 		return err
 	}
 	return c.String(http.StatusOK, "Delete winner")
+}
+
+// ユーザーに紐づいたウィナーの取得
+func (w *winnerController) IndexWinnerLinkUser(c echo.Context) error {
+	winners, err := w.winnerUsecase.FindAllWinnersLinkUser()
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, winners)
+}
+
+// イベントに紐づいたウィナーの取得
+func (w *winnerController) ShowWinnerLinkUser(c echo.Context) error {
+	id, _ := strconv.Atoi(c.Param("id"))
+	winner, err := w.winnerUsecase.FindWinnerLinkUser(id)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, winner)
 }

--- a/go_api/interfaces/winner_controller.go
+++ b/go_api/interfaces/winner_controller.go
@@ -50,10 +50,10 @@ func (w *winnerController) ShowWinner(c echo.Context) error {
 
 // ウィナーの作成
 func (w *winnerController) CreateWinner(c echo.Context) error {
-	user_id, _ := strconv.Atoi(c.QueryParam("user_id"))
+	UserID, _ := strconv.Atoi(c.QueryParam("user_id"))
 
 	winner := &domain.Winner{
-		UserID:    uint(user_id),
+		UserID:    uint(UserID),
 		CreatedAT: time.Now(),
 		UpdatedAT: time.Now(),
 	}
@@ -66,11 +66,11 @@ func (w *winnerController) CreateWinner(c echo.Context) error {
 // ウィナーの更新
 func (w *winnerController) UpdateWinner(c echo.Context) error {
 	id, _ := strconv.Atoi(c.Param("id"))
-	user_id, _ := strconv.Atoi(c.QueryParam("user_id"))
+	UserID, _ := strconv.Atoi(c.QueryParam("user_id"))
 
 	winner := &domain.Winner{
 		ID:        uint(id),
-		UserID:    uint(user_id),
+		UserID:    uint(UserID),
 		UpdatedAT: time.Now(),
 	}
 	if err := w.winnerUsecase.UpdateWinner(winner); err != nil {

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -85,6 +85,8 @@ func main() {
 	e.POST("/winners", winnerController.CreateWinner)
 	e.PUT("/winners/:id", winnerController.UpdateWinner)
 	e.DELETE("/winners/:id", winnerController.DeleteWinner)
+	e.GET("/winners/users", winnerController.IndexWinnerLinkUser)
+	e.GET("/winners/:id/users", winnerController.ShowWinnerLinkUser)
 
 	e.GET("/swagger/*", echoSwagger.WrapHandler)
 	e.GET("/checkswagger/", checkswagger)

--- a/go_api/usecase/winner_usecase.go
+++ b/go_api/usecase/winner_usecase.go
@@ -15,7 +15,7 @@ type WinnerUsecase interface {
 	CreateWinner(winner *domain.Winner) error
 	UpdateWinner(winner *domain.Winner) error
 	DeleteWinner(id int) error
-	FindAllWinnersLinkUser() (*domain.Winners, error)
+	FindAllWinnersLinkUser() (*domain.WinnerIncludedUsers, error)
 	FindWinnerLinkUser(id int) (*domain.Winner, error)
 }
 
@@ -66,12 +66,12 @@ func (w *winnerUsecase) DeleteWinner(id int) error {
 }
 
 // ユーザーに紐づいた全イベントの取得
-func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.Winners, error) {
-	winners, err := w.winnerRepository.FindAllLinkUser()
+func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.WinnerIncludedUsers, error) {
+	winnersIncludeUsers, err := w.winnerRepository.FindAllLinkUser()
 	if err != nil {
 		return nil, err
 	}
-	return winners, nil
+	return winnersIncludeUsers, nil
 }
 
 // ユーザーに紐づいたイベントの取得

--- a/go_api/usecase/winner_usecase.go
+++ b/go_api/usecase/winner_usecase.go
@@ -15,8 +15,8 @@ type WinnerUsecase interface {
 	CreateWinner(winner *domain.Winner) error
 	UpdateWinner(winner *domain.Winner) error
 	DeleteWinner(id int) error
-	FindAllWinnersLinkUser() (*domain.WinnersIncludeUsers, error)
-	FindWinnerLinkUser(id int) (*domain.WinnersIncludeUsers, error)
+	FindAllWinnersLinkUser() (*domain.Users, error)
+	FindWinnerLinkUser(id int) (*domain.User, error)
 }
 
 func NewWinnerUsecase(wr domain.WinnerRepository) WinnerUsecase {
@@ -66,7 +66,7 @@ func (w *winnerUsecase) DeleteWinner(id int) error {
 }
 
 // ユーザーに紐づいた全イベントの取得
-func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.WinnersIncludeUsers, error) {
+func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.Users, error) {
 	winnersIncludeUsers, err := w.winnerRepository.FindAllLinkUser()
 	if err != nil {
 		return nil, err
@@ -75,10 +75,10 @@ func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.WinnersIncludeUsers, e
 }
 
 // ユーザーに紐づいたイベントの取得
-func (w *winnerUsecase) FindWinnerLinkUser(id int) (*domain.WinnersIncludeUsers, error) {
-	winnersIncludeUsers, err := w.winnerRepository.FindLinkUser(id)
+func (w *winnerUsecase) FindWinnerLinkUser(id int) (*domain.User, error) {
+	winnersIncludeUser, err := w.winnerRepository.FindLinkUser(id)
 	if err != nil {
 		return nil, err
 	}
-	return winnersIncludeUsers, nil
+	return winnersIncludeUser, nil
 }

--- a/go_api/usecase/winner_usecase.go
+++ b/go_api/usecase/winner_usecase.go
@@ -15,6 +15,8 @@ type WinnerUsecase interface {
 	CreateWinner(winner *domain.Winner) error
 	UpdateWinner(winner *domain.Winner) error
 	DeleteWinner(id int) error
+	FindAllWinnersLinkUser() (*domain.Winners, error)
+	FindWinnerLinkUser(id int) (*domain.Winner, error)
 }
 
 func NewWinnerUsecase(wr domain.WinnerRepository) WinnerUsecase {
@@ -61,4 +63,22 @@ func (w *winnerUsecase) DeleteWinner(id int) error {
 		return err
 	}
 	return nil
+}
+
+// ユーザーに紐づいた全イベントの取得
+func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.Winners, error) {
+	winners, err := w.winnerRepository.FindAllLinkUser()
+	if err != nil {
+		return nil, err
+	}
+	return winners, nil
+}
+
+// ユーザーに紐づいたイベントの取得
+func (w *winnerUsecase) FindWinnerLinkUser(id int) (*domain.Winner, error) {
+	winner, err := w.winnerRepository.FindLinkUser(id)
+	if err != nil {
+		return nil, err
+	}
+	return winner, nil
 }

--- a/go_api/usecase/winner_usecase.go
+++ b/go_api/usecase/winner_usecase.go
@@ -15,8 +15,8 @@ type WinnerUsecase interface {
 	CreateWinner(winner *domain.Winner) error
 	UpdateWinner(winner *domain.Winner) error
 	DeleteWinner(id int) error
-	FindAllWinnersLinkUser() (*domain.Winners, error)
-	FindWinnerLinkUser(id int) (*domain.Winner, error)
+	FindAllWinnersLinkUser() (*domain.WinnersIncludeUsers, error)
+	FindWinnerLinkUser(id int) (*domain.WinnersIncludeUsers, error)
 }
 
 func NewWinnerUsecase(wr domain.WinnerRepository) WinnerUsecase {
@@ -66,19 +66,19 @@ func (w *winnerUsecase) DeleteWinner(id int) error {
 }
 
 // ユーザーに紐づいた全イベントの取得
-func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.Winners, error) {
-	winners, err := w.winnerRepository.FindAllLinkUser()
+func (w *winnerUsecase) FindAllWinnersLinkUser() (*domain.WinnersIncludeUsers, error) {
+	winnersIncludeUsers, err := w.winnerRepository.FindAllLinkUser()
 	if err != nil {
 		return nil, err
 	}
-	return winners, nil
+	return winnersIncludeUsers, nil
 }
 
 // ユーザーに紐づいたイベントの取得
-func (w *winnerUsecase) FindWinnerLinkUser(id int) (*domain.Winner, error) {
-	winner, err := w.winnerRepository.FindLinkUser(id)
+func (w *winnerUsecase) FindWinnerLinkUser(id int) (*domain.WinnersIncludeUsers, error) {
+	winnersIncludeUsers, err := w.winnerRepository.FindLinkUser(id)
 	if err != nil {
 		return nil, err
 	}
-	return winner, nil
+	return winnersIncludeUsers, nil
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 概要
Winnerに紐づくUserを表示させるAPIを作成しました。

動作手順
`make run`
`http://localhost:1323/swagger/index.html#/`の`/winners/users`と`/winners/:id/users`が正常に動作するか

<!-- 開発内容の概要を記載 -->
resolve #268 

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
- スクリーンショット
<img width="251" alt="image" src="https://user-images.githubusercontent.com/106811268/206393192-a6fcd562-cfc4-48e4-bba2-372dec441d0f.png">

## テスト項目
<!-- テストしてほしい内容を記載 -->
-正常な動作ができているか確認お願いします。
-
-

## 備考
- user_idと表示されているのにuserでまたidを表示してるのがちょっと気になる。消し方わからないけど

- 既出だったら無視でいいです。domain.userの`Events []Events`→`Events []Event`にしないとswaggerの`users/events`の方でエラーが発生していた。developでもエラーになっていたので他issueで修正した方が良さげです。