### PR TITLE
EventとUserの中間テーブルのInsert機能の実装

### DIFF
--- a/go_api/docs/docs.go
+++ b/go_api/docs/docs.go
@@ -285,6 +285,31 @@ const docTemplate = `{
                 }
             }
         },
+        "/event-users":{
+            "post":{
+                tags: ["event-users"],
+                "description":"eventとuserの中間テーブルへのInsert",
+                "parameters": [
+                    {
+                        "name": "event_id",
+                        "type": "integer",
+                        "in": "query",
+                        "description": "EventID",
+                    },
+                    {
+                        "name": "user_id",
+                        "type": "integer",
+                        "in": "query",
+                        "description": "UserID",
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"Created Event-User",
+                    }
+                }
+            }
+        },
         "/users":{
             "get":{
                 tags: ["user"],

--- a/go_api/docs/docs.go
+++ b/go_api/docs/docs.go
@@ -305,7 +305,7 @@ const docTemplate = `{
                 ],
                 "responses":{
                     "200":{
-                        "description":"Created Event-User",
+                        "description":"Created Event-Users",
                     }
                 }
             }

--- a/go_api/domain/event.go
+++ b/go_api/domain/event.go
@@ -10,7 +10,7 @@ type Event struct {
 	Description string    `json:"description" gorm:"not null"`
 	CreatedAT   time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT   time.Time `json:"updated_at" gorm:"not null"`
-	Users       []User    `json:"user,omitempty" gorm:"many2many:event_user;"`
+	Users       []User    `json:"user,omitempty" gorm:"many2many:event_users;"`
 }
 
 type Events []Event

--- a/go_api/domain/event_user.go
+++ b/go_api/domain/event_user.go
@@ -1,0 +1,10 @@
+package domain
+
+type EventUsers struct {
+	EventID uint64 `json:"event_id"`
+	UserID  uint64 `json:"user_id"`
+}
+
+type EventUsersRepository interface {
+	Create(eventUsers *EventUsers) error
+}

--- a/go_api/domain/event_user.go
+++ b/go_api/domain/event_user.go
@@ -1,8 +1,8 @@
 package domain
 
 type EventUsers struct {
-	EventID uint64 `json:"event_id"`
-	UserID  uint64 `json:"user_id"`
+	EventID uint64 `json:"event_id" gorm:"not null;"`
+	UserID  uint64 `json:"user_id" gorm:"not null;"`
 }
 
 type EventUsersRepository interface {

--- a/go_api/domain/user.go
+++ b/go_api/domain/user.go
@@ -11,7 +11,7 @@ type User struct {
 	Number    uint64    `json:"number" gorm:"unique;not null"`
 	CreatedAT time.Time `json:"created_at" gorm:"not null"`
 	UpdatedAT time.Time `json:"updated_at" gorm:"not null"`
-	Events    []Events  `json:"event,omitempty" gorm:"many2many:event_user;"`
+	Events    []Event  `json:"event,omitempty" gorm:"many2many:event_users;"`
 }
 
 type Users []User

--- a/go_api/infrastructure/event_user.go
+++ b/go_api/infrastructure/event_user.go
@@ -1,0 +1,23 @@
+package infrastructure
+
+import (
+	"github.com/NUTFes/lottery/go_api/domain"
+	"gorm.io/gorm"
+)
+
+type EventUsersInfrastructure struct {
+	db *gorm.DB
+}
+
+func NewEventUsersInfrastructure(db *gorm.DB) *EventUsersInfrastructure {
+	return &EventUsersInfrastructure{db: db}
+}
+
+// 中間テーブルへのInsert
+func (e *EventUsersInfrastructure) Create(eventUsers *domain.EventUsers) error {
+	if err := e.db.Create(eventUsers).Error; err != nil {
+		return err
+	}
+	e.db.Debug().Create(eventUsers)
+	return nil
+}

--- a/go_api/interfaces/event_users_controler.go
+++ b/go_api/interfaces/event_users_controler.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/NUTFes/lottery/go_api/domain"
+	"github.com/NUTFes/lottery/go_api/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type eventUsersController struct {
+	eventUsersUsecase usecase.EventUsersUsecase
+}
+
+type EventUsersController interface {
+	CreateEventUsers(c echo.Context) error
+}
+
+func NewEventUsersController(eu usecase.EventUsersUsecase) EventUsersController {
+	return &eventUsersController{eventUsersUsecase: eu}
+}
+
+// 中間テーブルへのInsert
+func (eu *eventUsersController) CreateEventUsers(c echo.Context) error {
+	eventID, _ := strconv.ParseUint(c.QueryParam("event_id"), 10, 64)
+	userID, _ := strconv.ParseUint(c.QueryParam("user_id"), 10, 64)
+
+	eventUsers := &domain.EventUsers{
+		EventID: eventID,
+		UserID:  userID,
+	}
+	if err := eu.eventUsersUsecase.CreateEventUsers(eventUsers); err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, eventUsers)
+}

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -39,16 +39,19 @@ func main() {
 	// 依存の方向：controller -> usecase -> domain <- infrastructure
 	adminInfrastructure := infrastructure.NewAdminInfrastructure(client)
 	eventInfrastructure := infrastructure.NewEventInfrastructure(client)
+	eventUsersInfrastructure := infrastructure.NewEventUsersInfrastructure(client)
 	userInfrastructure := infrastructure.NewUserInfrastructure(client)
 	winnerInfrastructure := infrastructure.NewWinnerInfrastructure(client)
 
 	adminUsecase := usecase.NewAdminUsecase(adminInfrastructure)
 	eventUsecase := usecase.NewEventUsecase(eventInfrastructure)
+	eventUsersUsecase := usecase.NewEventUsersUsecase(eventUsersInfrastructure)
 	userUsecase := usecase.NewUserUsecase(userInfrastructure)
 	winnerUsecase := usecase.NewWinnerUsecase(winnerInfrastructure)
 
 	adminController := controller.NewAdminController(adminUsecase)
 	eventController := controller.NewEventController(eventUsecase)
+	eventUsersController := controller.NewEventUsersController(eventUsersUsecase)
 	userController := controller.NewUserController(userUsecase)
 	winnerController := controller.NewWinnerController(winnerUsecase)
 
@@ -69,6 +72,9 @@ func main() {
 	e.DELETE("/events/:id", eventController.DeleteEvent)
 	e.GET("/events/users", eventController.IndexEventLinkUser)
 	e.GET("/events/:id/users", eventController.ShowEventLinkUser)
+
+	// event_users
+	e.GET("/event-users", eventUsersController.CreateEventUsers)
 
 	// users
 	e.GET("/users", userController.IndexUser)

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -74,7 +74,7 @@ func main() {
 	e.GET("/events/:id/users", eventController.ShowEventLinkUser)
 
 	// event_users
-	e.GET("/event-users", eventUsersController.CreateEventUsers)
+	e.POST("/event-users", eventUsersController.CreateEventUsers)
 
 	// users
 	e.GET("/users", userController.IndexUser)

--- a/go_api/usecase/event_users_usecase.go
+++ b/go_api/usecase/event_users_usecase.go
@@ -1,0 +1,25 @@
+package usecase
+
+import (
+	"github.com/NUTFes/lottery/go_api/domain"
+)
+
+type eventUsersUsecase struct {
+	eventUsersRepository domain.EventUsersRepository
+}
+
+type EventUsersUsecase interface {
+	CreateEventUsers(eventUsers *domain.EventUsers) error
+}
+
+func NewEventUsersUsecase(eur domain.EventUsersRepository) EventUsersUsecase {
+	return &eventUsersUsecase{eventUsersRepository: eur}
+}
+
+// 中間テーブルへのInsert
+func (e *eventUsersUsecase) CreateEventUsers(eventUsers *domain.EventUsers) error {
+	if err := e.eventUsersRepository.Create(eventUsers); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 概要
EventとUserの中間テーブルのInsert機能の実装
<!-- 開発内容の概要を記載 -->
resolve #265 
中間テーブルを`event_user`から`event_users`に変更した 4d2ae6d9e470d1fe890149a8be3cf4baff7740c9
- 変更理由として、gormのメソッドを使う際に、基本的に内部のクエリではテーブルを指定する際に複数形になる。そのため、テーブルを`event_users`とすることで、gormのメソッドを利用できるようにした。

中間テーブルへのInsert機能の実装 3ec4478314334e8f61ce65b4e23f3eb61eafacf5
- 今まで通りの実装

swaggerに`event_users`の項目の追加 0b33e1c4684c5cf42038169016d4a9109d8d14aa

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
- スクリーンショット

## テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ]  swagger上で中間テーブルを作成することができるか
- `make run`でdbとapiサーバーを起動する
- mysql内に入り、`event_user`テーブルを削除する。
- `make run-initdb`で`event_users`テーブルを作成する。
- swagger上でevent_usersテーブルにinsertしてみる。
## 備考
