### PR TITLE
Dev/issue266

### DIFF
--- a/go_api/docs/docs.go
+++ b/go_api/docs/docs.go
@@ -308,6 +308,31 @@ const docTemplate = `{
                         "description":"Created Event-Users",
                     }
                 }
+            },
+            "delete":{
+                tags: ["event-users"],
+                "description":"eventとuserの中間テーブルのレコードのDelete",
+                "parameters": [
+                    {
+                        "name": "event_id",
+                        "type": "integer",
+                        "in": "query",
+                        "description": "EventID",
+                        "required": true
+                    },
+                    {
+                        "name": "user_id",
+                        "type": "integer",
+                        "in": "query",
+                        "description": "UserID",
+                        "required": true
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"Deleted Event-Users",
+                    }
+                }
             }
         },
         "/users":{

--- a/go_api/domain/event_user.go
+++ b/go_api/domain/event_user.go
@@ -7,4 +7,5 @@ type EventUsers struct {
 
 type EventUsersRepository interface {
 	Create(eventUsers *EventUsers) error
+	Delete(eventID uint64, userID uint64) error
 }

--- a/go_api/infrastructure/event_user.go
+++ b/go_api/infrastructure/event_user.go
@@ -21,3 +21,13 @@ func (e *EventUsersInfrastructure) Create(eventUsers *domain.EventUsers) error {
 	e.db.Debug().Create(eventUsers)
 	return nil
 }
+
+// 中間テーブルのレコードDelete
+func (e *EventUsersInfrastructure) Delete(eventID uint64, userID uint64) error {
+	eventUsers := domain.EventUsers{}
+	if err := e.db.Delete(&eventUsers, eventID, userID).Error; err != nil {
+		return err
+	}
+	e.db.Delete(&eventUsers, eventID, userID)
+	return nil
+}

--- a/go_api/interfaces/event_users_controler.go
+++ b/go_api/interfaces/event_users_controler.go
@@ -15,6 +15,7 @@ type eventUsersController struct {
 
 type EventUsersController interface {
 	CreateEventUsers(c echo.Context) error
+	DeleteEventUsers(c echo.Context) error
 }
 
 func NewEventUsersController(eu usecase.EventUsersUsecase) EventUsersController {
@@ -34,4 +35,15 @@ func (eu *eventUsersController) CreateEventUsers(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, eventUsers)
+}
+
+// 中間テーブルのレコードDelete
+func (eu *eventUsersController) DeleteEventUsers(c echo.Context) error {
+	eventID, _ := strconv.ParseUint(c.QueryParam("event_id"), 10, 64)
+	userID, _ := strconv.ParseUint(c.QueryParam("user_id"), 10, 64)
+
+	if err := eu.eventUsersUsecase.DeleteEventUsers(eventID, userID); err != nil {
+		return err
+	}
+	return c.String(http.StatusOK, "Delete EventUsers")
 }

--- a/go_api/main.go
+++ b/go_api/main.go
@@ -75,6 +75,7 @@ func main() {
 
 	// event_users
 	e.POST("/event-users", eventUsersController.CreateEventUsers)
+	e.DELETE("/event-users", eventUsersController.DeleteEventUsers)
 
 	// users
 	e.GET("/users", userController.IndexUser)

--- a/go_api/usecase/event_users_usecase.go
+++ b/go_api/usecase/event_users_usecase.go
@@ -10,6 +10,7 @@ type eventUsersUsecase struct {
 
 type EventUsersUsecase interface {
 	CreateEventUsers(eventUsers *domain.EventUsers) error
+	DeleteEventUsers(eventID uint64, userID uint64) error
 }
 
 func NewEventUsersUsecase(eur domain.EventUsersRepository) EventUsersUsecase {
@@ -19,6 +20,14 @@ func NewEventUsersUsecase(eur domain.EventUsersRepository) EventUsersUsecase {
 // 中間テーブルへのInsert
 func (e *eventUsersUsecase) CreateEventUsers(eventUsers *domain.EventUsers) error {
 	if err := e.eventUsersRepository.Create(eventUsers); err != nil {
+		return err
+	}
+	return nil
+}
+
+// 中間テーブルのレコードDelete
+func (e *eventUsersUsecase) DeleteEventUsers(eventID uint64, userID uint64) error {
+	if err := e.eventUsersRepository.Delete(eventID, userID); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
## 概要
usersとeventsの中間テーブルevent_usersのレコード削除機能の作成 d40a69c92223ea551b4a0233476eab5ee1862b19
swaggerにAPI追加 83f04fcc26816f416cb792ea85d5742970f414a1
<!-- 開発内容の概要を記載 -->
resolve #266 

## 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
- スクリーンショット

## テスト項目
<!-- テストしてほしい内容を記載 -->

- [ ] 中間テーブルが削除されるか。
- `make run`
- `swagger`にて、`event_id`と`user_id`を指定して中間テーブルを削除できるか確認する

## 備考
